### PR TITLE
ci: use macOS-10.14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
       - task: PublishBuildArtifacts@1
         inputs: { pathtoPublish: "wheelhouse" }
   - job: macos_wheels
-    pool: { vmImage: "macOS-10.13" }
+    pool: { vmImage: "macOS-10.14" }
     variables:
       LDFLAGS: "-L/usr/local/opt/libarchive/lib"
       CPPFLAGS: "-I/usr/local/opt/libarchive/include"


### PR DESCRIPTION
cause azure pipeline is sunsetting macOS-10.13